### PR TITLE
Add Slack travel bot skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/app.py
+++ b/app.py
@@ -1,0 +1,41 @@
+# Main entrypoint for the travel bot
+import os
+import logging
+from slack_bolt import App
+from slack_bolt.adapter.socket_mode import SocketModeHandler
+
+from services.sheets import SheetService
+from services.firebase import FirebaseService
+from services.ai import ConversationalAI
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+slack_bot_token = os.environ.get("SLACK_BOT_TOKEN")
+slack_app_token = os.environ.get("SLACK_APP_TOKEN")
+
+if not slack_bot_token or not slack_app_token:
+    raise ValueError("SLACK_BOT_TOKEN and SLACK_APP_TOKEN must be set")
+
+app = App(token=slack_bot_token)
+
+sheet_service = SheetService()
+firebase_service = FirebaseService()
+ai_service = ConversationalAI()
+
+@app.event("app_mention")
+@app.event("message")
+def handle_message(event, say):
+    user = event.get("user")
+    text = event.get("text", "")
+    if not user:
+        return
+
+    logger.info("Received message from %s: %s", user, text)
+
+    response = ai_service.process_message(user, text)
+    say(response)
+
+if __name__ == "__main__":
+    handler = SocketModeHandler(app, slack_app_token)
+    handler.start()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+slack_bolt
+google-auth
+gspread
+firebase-admin
+llama-cpp-python
+pytest

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,0 +1,1 @@
+"""Service package for travel bot."""

--- a/services/ai.py
+++ b/services/ai.py
@@ -1,0 +1,55 @@
+import logging
+
+try:
+    from google.generativeai import GenerativeModel
+    GEMINI_AVAILABLE = True
+except Exception as e:
+    logging.warning("Gemini not available: %s", e)
+    GEMINI_AVAILABLE = False
+
+# Placeholder for fallback open-source model (e.g., llama-cpp-python)
+try:
+    from llama_cpp import Llama
+    LLAMA_AVAILABLE = True
+except Exception as e:
+    logging.warning("Llama model not available: %s", e)
+    LLAMA_AVAILABLE = False
+
+logger = logging.getLogger(__name__)
+
+class ConversationalAI:
+    def __init__(self):
+        self.gemini_model = None
+        if GEMINI_AVAILABLE:
+            try:
+                self.gemini_model = GenerativeModel("gemini-pro")
+                logger.info("Using Gemini model")
+            except Exception as e:
+                logger.error("Failed to init Gemini: %s", e)
+                self.gemini_model = None
+        self.llama_model = None
+        if not self.gemini_model and LLAMA_AVAILABLE:
+            try:
+                self.llama_model = Llama(model_path="model.bin")
+                logger.info("Using Llama fallback model")
+            except Exception as e:
+                logger.error("Failed to load Llama: %s", e)
+                self.llama_model = None
+
+    def process_message(self, user: str, text: str) -> str:
+        if self.gemini_model:
+            try:
+                response = self.gemini_model.generate_content(text)
+                return response.text
+            except Exception as e:
+                logger.error("Gemini error: %s", e)
+                self.gemini_model = None
+        if self.llama_model:
+            try:
+                output = self.llama_model(text)
+                return output["choices"][0]["text"]
+            except Exception as e:
+                logger.error("Llama error: %s", e)
+                self.llama_model = None
+        logger.error("No conversational AI available")
+        return "Lo siento, actualmente no puedo procesar tu solicitud."

--- a/services/firebase.py
+++ b/services/firebase.py
@@ -1,0 +1,31 @@
+import os
+import logging
+from typing import Any
+import firebase_admin
+from firebase_admin import credentials, firestore
+
+logger = logging.getLogger(__name__)
+
+class FirebaseService:
+    def __init__(self):
+        creds_json = os.environ.get("GOOGLE_SERVICE_ACCOUNT")
+        if not creds_json:
+            logger.warning("GOOGLE_SERVICE_ACCOUNT not set; Firebase disabled")
+            self.client = None
+            return
+        cred = credentials.Certificate(creds_json)
+        firebase_admin.initialize_app(cred)
+        self.client = firestore.client()
+
+    def get_user_data(self, slack_id: str) -> dict | None:
+        if not self.client:
+            return None
+        doc = self.client.collection("users").document(slack_id).get()
+        if doc.exists:
+            return doc.to_dict()
+        return None
+
+    def save_user_data(self, slack_id: str, data: dict[str, Any]):
+        if not self.client:
+            return
+        self.client.collection("users").document(slack_id).set(data, merge=True)

--- a/services/sheets.py
+++ b/services/sheets.py
@@ -1,0 +1,32 @@
+import os
+import logging
+import gspread
+from google.oauth2.service_account import Credentials
+
+logger = logging.getLogger(__name__)
+
+SCOPES = ["https://www.googleapis.com/auth/spreadsheets.readonly"]
+
+class SheetService:
+    def __init__(self):
+        creds_json = os.environ.get("GOOGLE_SERVICE_ACCOUNT")
+        if not creds_json:
+            logger.warning("GOOGLE_SERVICE_ACCOUNT not set; Sheets access disabled")
+            self.client = None
+        else:
+            creds = Credentials.from_service_account_file(creds_json, scopes=SCOPES)
+            self.client = gspread.authorize(creds)
+        self.sheet_id = os.environ.get("GOOGLE_SHEET_ID")
+
+    def get_user(self, slack_id: str) -> dict | None:
+        if not self.client or not self.sheet_id:
+            return None
+        try:
+            sheet = self.client.open_by_key(self.sheet_id).sheet1
+            records = sheet.get_all_records()
+            for row in records:
+                if row.get("slack_id") == slack_id:
+                    return row
+        except Exception as e:
+            logger.error("Error accessing Google Sheets: %s", e)
+        return None

--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -1,0 +1,12 @@
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from services.ai import ConversationalAI
+
+def test_ai_fallback():
+    ai = ConversationalAI()
+    response = ai.process_message("test", "Hola")
+    assert isinstance(response, str)
+
+if __name__ == "__main__":
+    import sys
+    sys.path.append('..')


### PR DESCRIPTION
## Summary
- set up a Python skeleton for a travel request bot
- implement simple Slack event handling
- add Google Sheets and Firebase service stubs
- add conversational AI module with Gemini and Llama fallback
- include minimal unit test

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68853dfad28483258787d6c9430819f5