### PR TITLE
Add HTTP Slack endpoint and Gemini integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -4,6 +4,57 @@ Conéctate a Google Sheets (para consultar usuarios y políticas), Firebase (par
 
 No uses la API de Okibi ni ninguna solución de pago para IA conversacional. Prioriza siempre servicios gratuitos, open source o económicos.
 
+## Instalación y configuración
+
+1. Instala las dependencias de Python:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. Define las siguientes variables de entorno para ejecutar el bot:
+
+   - `SLACK_BOT_TOKEN` y `SLACK_SIGNING_SECRET`: credenciales de tu aplicación Slack.
+   - `GEMINI_API_KEY`: API key para la librería oficial `google-genai`.
+   - `GOOGLE_SHEET_ID`: ID de la hoja de Google Sheets que contiene la información de usuarios.
+   - `GOOGLE_SERVICE_ACCOUNT`: ruta al JSON del servicio de Google para acceder a Sheets y Firebase.
+   - `LLAMA_MODEL_PATH` (opcional): modelo local a usar si Gemini falla.
+
+3. Ejecuta la aplicación de desarrollo:
+
+   ```bash
+   python app.py
+   ```
+
+   El servidor se inicia en `http://0.0.0.0:8080`.
+
+## Endpoint de Slack
+
+El bot recibe todos los eventos de Slack vía HTTP POST en la ruta:
+
+```
+https://travelbot-slack-uxcqgkjcna-uc.a.run.app/slack/events
+```
+
+Registra esta URL en Slack (Event Subscriptions > Request URL). La firma se valida automáticamente usando los encabezados `X-Slack-Signature` y `X-Slack-Request-Timestamp` según la [documentación oficial](https://api.slack.com/authentication/verifying-requests-from-slack).
+
+## Uso de Gemini
+
+El código sigue la guía oficial de [google-genai](https://github.com/googleapis/python-genai) para generar contenido:
+
+```python
+from google import genai
+
+client = genai.Client(api_key=os.environ["GEMINI_API_KEY"])
+response = client.models.generate_content(
+    model="gemini-2.5-flash",
+    contents="mensaje del usuario aquí",
+)
+texto = response.text
+```
+
+Si Gemini no está disponible, se usa un modelo open source (por ejemplo, Llama) como respaldo automático.
+
 Requisitos funcionales y reglas
 Conversación natural: El bot debe interpretar y responder mensajes en lenguaje libre (“hola”, “viajo a Madrid”, “voy de CDMX a NYC del 12 al 16”). Extrae todos los datos relevantes, confirma, pide lo que falta y nunca fuerza formatos rígidos.
 

--- a/app.py
+++ b/app.py
@@ -1,0 +1,59 @@
+import logging
+import os
+import threading
+from flask import Flask, request
+from slack_bolt import App
+from slack_bolt.adapter.flask import SlackRequestHandler
+
+from services.sheets import SheetService
+from services.firebase import FirebaseService
+from services.ai import ConversationalAI
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+slack_bot_token = os.environ.get("SLACK_BOT_TOKEN")
+slack_signing_secret = os.environ.get("SLACK_SIGNING_SECRET")
+
+if not slack_bot_token or not slack_signing_secret:
+    raise ValueError("SLACK_BOT_TOKEN and SLACK_SIGNING_SECRET must be set")
+
+bolt_app = App(token=slack_bot_token, signing_secret=slack_signing_secret)
+handler = SlackRequestHandler(bolt_app)
+
+sheet_service = SheetService()
+firebase_service = FirebaseService()
+ai_service = ConversationalAI()
+
+
+def process_and_respond(body, say):
+    user = body.get("event", {}).get("user")
+    text = body.get("event", {}).get("text", "")
+    if not user:
+        return
+    logger.info("Received message from %s: %s", user, text)
+    response = ai_service.process_message(user, text)
+    say(response)
+
+
+@bolt_app.event("message")
+def handle_message(event, say, ack):
+    ack()
+    if event.get("subtype") or event.get("bot_id"):
+        return
+    if event.get("channel_type") != "im":
+        return
+    body = {"event": event}
+    threading.Thread(target=process_and_respond, args=(body, say)).start()
+
+
+flask_app = Flask(__name__)
+
+
+@flask_app.route("/slack/events", methods=["POST"])
+def slack_events():
+    return handler.handle(request)
+
+
+if __name__ == "__main__":
+    flask_app.run(host="0.0.0.0", port=8080)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+Flask
+slack_bolt
+google-genai
+google-auth
+gspread
+firebase-admin
+llama-cpp-python
+pytest

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,0 +1,1 @@
+"""Service package for travel bot."""

--- a/services/ai.py
+++ b/services/ai.py
@@ -1,0 +1,53 @@
+import logging
+import os
+
+try:
+    from google import genai
+    api_key = os.environ.get("GEMINI_API_KEY")
+    GEMINI_AVAILABLE = bool(api_key)
+except Exception as e:
+    logging.warning("Gemini not available: %s", e)
+    GEMINI_AVAILABLE = False
+
+try:
+    from llama_cpp import Llama
+    LLAMA_AVAILABLE = True
+except Exception as e:
+    logging.warning("Llama model not available: %s", e)
+    LLAMA_AVAILABLE = False
+
+logger = logging.getLogger(__name__)
+
+
+class ConversationalAI:
+    def __init__(self):
+        self.client = genai.Client(api_key=api_key) if GEMINI_AVAILABLE else None
+        self.llama_model = None
+        if not self.client and LLAMA_AVAILABLE and os.environ.get("LLAMA_MODEL_PATH"):
+            try:
+                self.llama_model = Llama(model_path=os.environ["LLAMA_MODEL_PATH"])
+                logger.info("Using Llama fallback model")
+            except Exception as e:
+                logger.error("Failed to load Llama: %s", e)
+                self.llama_model = None
+
+    def process_message(self, user: str, text: str) -> str:
+        if self.client:
+            try:
+                response = self.client.models.generate_content(
+                    model="gemini-2.5-flash",
+                    contents=text,
+                )
+                return response.text
+            except Exception as e:
+                logger.error("Gemini error: %s", e)
+                self.client = None
+        if self.llama_model:
+            try:
+                output = self.llama_model(text)
+                return output["choices"][0]["text"]
+            except Exception as e:
+                logger.error("Llama error: %s", e)
+                self.llama_model = None
+        logger.error("No conversational AI available")
+        return "Lo siento, actualmente no puedo procesar tu solicitud."

--- a/services/firebase.py
+++ b/services/firebase.py
@@ -1,0 +1,31 @@
+import os
+import logging
+from typing import Any
+import firebase_admin
+from firebase_admin import credentials, firestore
+
+logger = logging.getLogger(__name__)
+
+class FirebaseService:
+    def __init__(self):
+        creds_json = os.environ.get("GOOGLE_SERVICE_ACCOUNT")
+        if not creds_json:
+            logger.warning("GOOGLE_SERVICE_ACCOUNT not set; Firebase disabled")
+            self.client = None
+            return
+        cred = credentials.Certificate(creds_json)
+        firebase_admin.initialize_app(cred)
+        self.client = firestore.client()
+
+    def get_user_data(self, slack_id: str) -> dict | None:
+        if not self.client:
+            return None
+        doc = self.client.collection("users").document(slack_id).get()
+        if doc.exists:
+            return doc.to_dict()
+        return None
+
+    def save_user_data(self, slack_id: str, data: dict[str, Any]):
+        if not self.client:
+            return
+        self.client.collection("users").document(slack_id).set(data, merge=True)

--- a/services/sheets.py
+++ b/services/sheets.py
@@ -1,0 +1,32 @@
+import os
+import logging
+import gspread
+from google.oauth2.service_account import Credentials
+
+logger = logging.getLogger(__name__)
+
+SCOPES = ["https://www.googleapis.com/auth/spreadsheets.readonly"]
+
+class SheetService:
+    def __init__(self):
+        creds_json = os.environ.get("GOOGLE_SERVICE_ACCOUNT")
+        if not creds_json:
+            logger.warning("GOOGLE_SERVICE_ACCOUNT not set; Sheets access disabled")
+            self.client = None
+        else:
+            creds = Credentials.from_service_account_file(creds_json, scopes=SCOPES)
+            self.client = gspread.authorize(creds)
+        self.sheet_id = os.environ.get("GOOGLE_SHEET_ID")
+
+    def get_user(self, slack_id: str) -> dict | None:
+        if not self.client or not self.sheet_id:
+            return None
+        try:
+            sheet = self.client.open_by_key(self.sheet_id).sheet1
+            records = sheet.get_all_records()
+            for row in records:
+                if row.get("slack_id") == slack_id:
+                    return row
+        except Exception as e:
+            logger.error("Error accessing Google Sheets: %s", e)
+        return None

--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -1,0 +1,12 @@
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from services.ai import ConversationalAI
+
+def test_ai_fallback():
+    ai = ConversationalAI()
+    response = ai.process_message("test", "Hola")
+    assert isinstance(response, str)
+
+if __name__ == "__main__":
+    import sys
+    sys.path.append('..')


### PR DESCRIPTION
## Summary
- handle Slack messages over HTTP POST at `/slack/events`
- validate Slack signatures and process DM messages asynchronously
- integrate Gemini via `google-genai` with optional Llama fallback
- update dependencies for Flask and google-genai
- document setup and API usage in README
- fix Gemini client initialization

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68853dfad28483258787d6c9430819f5