### PR TITLE
Switch to Gemini 2.5 Flash

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Creai TravelBot es un asistente para gestionar solicitudes de viaje corporativo 
 
 - Conversación natural por DM en Slack.
 - **Eventos recibidos únicamente por HTTP POST** en `/slack/events`.
-- IA principal: Gemini (`google-generativeai`) con fallback a modelos open source.
+- IA principal: Gemini 2.5 Flash (`google-generativeai`) con fallback a modelos open source.
 - Configuración de usuarios en Google Sheets y almacenamiento seguro en Firebase.
 - Validación de firmas de Slack y registro detallado de errores.
 
@@ -70,7 +70,7 @@ El bot emplea el paquete `google-generativeai` siguiendo la guía oficial de
 ```python
 from google import generativeai as genai
 genai.configure(api_key=os.environ["GEMINI_API_KEY"])
-model = genai.GenerativeModel("gemini-pro")
+model = genai.GenerativeModel("gemini-2.5-flash")
 ```
 
 Todas las llamadas deben realizarse tal cual lo especifica la documentación,

--- a/services/ai.py
+++ b/services/ai.py
@@ -28,8 +28,8 @@ class ConversationalAI:
         if GEMINI_AVAILABLE:
             try:
                 from google.generativeai import GenerativeModel
-                self.gemini_model = GenerativeModel("gemini-pro")
-                logger.info("Using Gemini model")
+                self.gemini_model = GenerativeModel("gemini-2.5-flash")
+                logger.info("Using Gemini 2.5 Flash model")
             except Exception as e:
                 logger.error("Failed to init Gemini: %s", e)
                 self.gemini_model = None


### PR DESCRIPTION
## Summary
- set default Gemini model to `gemini-2.5-flash`
- document Gemini 2.5 Flash as the main model in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688548b650c883258b4af16c98e2d44c