### PR TITLE
Implement Travel conversation state

### DIFF
--- a/services/state.py
+++ b/services/state.py
@@ -1,0 +1,24 @@
+from dataclasses import dataclass, field
+from typing import Optional, Dict
+
+@dataclass
+class TravelState:
+    """Conversation state for a travel request."""
+
+    origin: Optional[str] = None
+    destination: Optional[str] = None
+    start_date: Optional[str] = None
+    end_date: Optional[str] = None
+    venue: Optional[str] = None
+    reason: Optional[str] = None
+    flight_pref: Optional[str] = None
+    hotel_pref: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, str]:
+        return {k: v for k, v in self.__dict__.items() if v}
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, str]):
+        if not data:
+            return cls()
+        return cls(**data)

--- a/services/travel.py
+++ b/services/travel.py
@@ -1,5 +1,8 @@
 import logging
+import re
 from typing import Any, List
+
+from .state import TravelState
 
 from .firebase import FirebaseService
 from .sheets import SheetService
@@ -30,13 +33,40 @@ class TravelAssistant:
             sheet_user = self.sheets.get_user(slack_id)
             if sheet_user:
                 data.update(sheet_user)
-                self.firebase.save_user_data(slack_id, data)
+        if "history" not in data:
+            data["history"] = []
+        if "state" not in data:
+            data["state"] = {}
+        self.firebase.save_user_data(slack_id, data)
         return data
 
     def _save_history(self, slack_id: str, history: List[dict]):
         self.firebase.save_user_data(slack_id, {"history": history})
 
-    def build_prompt(self, user_data: dict, history: List[dict], message: str) -> str:
+    def _load_state(self, user_data: dict) -> TravelState:
+        return TravelState.from_dict(user_data.get("state", {}))
+
+    def _save_state(self, slack_id: str, state: TravelState):
+        self.firebase.save_user_data(slack_id, {"state": state.to_dict()})
+
+    def _parse_message(self, state: TravelState, text: str):
+        """Extract basic travel information from the user's message."""
+        if not state.origin or not state.destination:
+            codes = re.findall(r"\b[A-Z]{3}\b", text.upper())
+            if codes:
+                if not state.origin and len(codes) >= 1:
+                    state.origin = codes[0]
+                if not state.destination and len(codes) >= 2:
+                    state.destination = codes[1]
+        if not state.start_date or not state.end_date:
+            dates = re.findall(r"\d{4}-\d{2}-\d{2}", text)
+            if dates:
+                if not state.start_date and len(dates) >= 1:
+                    state.start_date = dates[0]
+                if not state.end_date and len(dates) >= 2:
+                    state.end_date = dates[1]
+
+    def build_prompt(self, user_data: dict, state: TravelState, history: List[dict], message: str) -> str:
         policy = (
             "Política de Viajes Creai:\n"
             "Reservaciones 7 días antes, info completa obligatoria.\n"
@@ -48,19 +78,37 @@ class TravelAssistant:
             "Casos especiales: Solo con autorización de Presidencia."
         )
         context = "\n".join(
-            f"Usuario: {h['user']}" if 'user' in h else f"Bot: {h['bot']}" for h in history
+            f"Usuario: {h['user']}" if 'user' in h else f"Bot: {h['bot']}" for h in history[-5:]
         )
-        prompt = f"{policy}\n{context}\nUsuario: {message}\nBot:".strip()
-        return prompt
+        state_lines = "\n".join(f"{k}: {v}" for k, v in state.to_dict().items()) or "ninguno"
+        missing = [
+            f for f in ["origin", "destination", "start_date", "end_date"] if not getattr(state, f)
+        ]
+        missing_text = ", ".join(missing) if missing else "ninguno"
+        prompt = (
+            f"{policy}\n"
+            f"Datos recopilados:\n{state_lines}\n"
+            f"Faltantes: {missing_text}\n"
+            f"{context}\n"
+            f"Usuario: {message}\nBot:"
+        )
+        return prompt.strip()
 
     def handle_message(self, slack_id: str, text: str) -> str:
         user_data = self._load_user(slack_id)
         history = user_data.get("history", [])
+        state = self._load_state(user_data)
         history.append({"user": text})
-        prompt = self.build_prompt(user_data, history, text)
+
+        self._parse_message(state, text)
+
+        prompt = self.build_prompt(user_data, state, history, text)
         response = self.ai.process_message(slack_id, prompt)
+
         history.append({"bot": response})
-        self._save_history(slack_id, history[-20:])  # keep last 20 messages
+        self._save_history(slack_id, history[-20:])
+        self._save_state(slack_id, state)
+
         return response
 
     # Example methods for fetching travel data


### PR DESCRIPTION
## Summary
- manage conversation info with `TravelState`
- update `TravelAssistant` to parse messages and store conversation state
- keep Slack integration intact
- add simple regex-based extraction of origin, destination and dates

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68858f3864a08325be107a0f87ae707c