### PR TITLE
Implement extended travel state parsing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@
 Flask
 slack_bolt
 google-genai
-slack_bolt
 google-auth
 gspread
 firebase-admin

--- a/services/state.py
+++ b/services/state.py
@@ -13,6 +13,12 @@ class TravelState:
     reason: Optional[str] = None
     flight_pref: Optional[str] = None
     hotel_pref: Optional[str] = None
+    frequent_flyer: Optional[str] = None
+    seat_pref: Optional[str] = None
+    budget: Optional[str] = None
+    passport: Optional[bool] = None
+    visa: Optional[bool] = None
+    share_room: Optional[bool] = None
 
     def to_dict(self) -> Dict[str, str]:
         return {k: v for k, v in self.__dict__.items() if v}

--- a/services/travel.py
+++ b/services/travel.py
@@ -65,6 +65,23 @@ class TravelAssistant:
                     state.start_date = dates[0]
                 if not state.end_date and len(dates) >= 2:
                     state.end_date = dates[1]
+        if not state.seat_pref:
+            if "ventana" in text.lower():
+                state.seat_pref = "ventana"
+            elif "pasillo" in text.lower():
+                state.seat_pref = "pasillo"
+        if not state.share_room and "compartir" in text.lower():
+            state.share_room = True
+        if "no compartir" in text.lower():
+            state.share_room = False
+        if not state.passport and "pasaporte" in text.lower():
+            state.passport = "si" in text.lower()
+        if not state.visa and "visa" in text.lower():
+            state.visa = "si" in text.lower()
+        if not state.budget:
+            m = re.search(r"(?:\$|presupuesto\s*)(\d+)", text.lower())
+            if m:
+                state.budget = m.group(1)
 
     def build_prompt(self, user_data: dict, state: TravelState, history: List[dict], message: str) -> str:
         policy = (
@@ -81,9 +98,8 @@ class TravelAssistant:
             f"Usuario: {h['user']}" if 'user' in h else f"Bot: {h['bot']}" for h in history[-5:]
         )
         state_lines = "\n".join(f"{k}: {v}" for k, v in state.to_dict().items()) or "ninguno"
-        missing = [
-            f for f in ["origin", "destination", "start_date", "end_date"] if not getattr(state, f)
-        ]
+        required_fields = ["origin", "destination", "start_date", "end_date"]
+        missing = [f for f in required_fields if not getattr(state, f)]
         missing_text = ", ".join(missing) if missing else "ninguno"
         prompt = (
             f"{policy}\n"

--- a/tests/test_travel.py
+++ b/tests/test_travel.py
@@ -1,8 +1,8 @@
-import sys
-import os
+import sys, os
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 from services.travel import TravelAssistant
+from services.state import TravelState
 from services.sheets import SheetService
 from services.firebase import FirebaseService
 from services.ai import ConversationalAI
@@ -13,3 +13,14 @@ def test_travel_assistant_basic():
     ta = TravelAssistant(SheetService(), FirebaseService(), ConversationalAI(), SerpAPIService())
     resp = ta.handle_message("U123", "Hola")
     assert isinstance(resp, str)
+
+
+def test_parse_message_extended():
+    ta = TravelAssistant(SheetService(), FirebaseService(), ConversationalAI(), SerpAPIService())
+    state = TravelState()
+    ta._parse_message(state, "Quiero viajar de MEX a NYC el 2024-09-10, prefiero ventana y presupuesto $500")
+    assert state.origin == "MEX"
+    assert state.destination == "NYC"
+    assert state.start_date == "2024-09-10"
+    assert state.seat_pref == "ventana"
+    assert state.budget == "500"


### PR DESCRIPTION
## Summary
- remove duplicated dependency in requirements
- store more fields in `TravelState`
- parse seat preference, budget, room sharing, passport and visa from messages
- add tests for extended parsing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688590c4e5e08325a75b635f5ff924bd