### PR TITLE
Update policy prompt and ensure carry-on in search

### DIFF
--- a/services/params.py
+++ b/services/params.py
@@ -193,6 +193,7 @@ def build_flight_params(
         "gl": gl,
         "currency": currency,
         "travel_class": travel_class,
+        "bags": "1",
     }
     if dep:
         params["departure_id"] = dep

--- a/services/serpapi.py
+++ b/services/serpapi.py
@@ -34,6 +34,7 @@ class SerpAPIService:
             "departure_id": origin,
             "arrival_id": destination,
             "outbound_date": date,
+            "bags": "1",
         }
         data = self._request("search", params)
         return data.get("flights_results", []) if data else []

--- a/services/travel.py
+++ b/services/travel.py
@@ -85,14 +85,14 @@ class TravelAssistant:
 
     def build_prompt(self, user_data: dict, state: TravelState, history: List[dict], message: str) -> str:
         policy = (
-            "Política de Viajes Creai:\n"
-            "Reservaciones 7 días antes, info completa obligatoria.\n"
-            "Vuelos: Económica, carry-on incluido, asiento seleccionable según política, premier solo con autorización especial.\n"
-            "Hospedaje: Límite por seniority y región. Hoteles seguros y cerca del venue. Habitación compartida solo si el usuario acepta.\n"
-            "Viáticos: Por país, justificación o anticipo según política.\n"
-            "Autorizaciones: Finanzas autoriza, Presidencia para excepciones.\n"
-            "No cubierto: fechas fuera del evento, room service, minibar, spa, gimnasio, transporte ajeno, etc.\n"
-            "Casos especiales: Solo con autorización de Presidencia."
+            "Eres un asistente de viajes corporativos integrado con Slack y Google Sheets.\n"
+            "Obtén nombre completo, fecha de nacimiento, seniority y departamento automáticamente con el Slack ID.\n"
+            "Solo pregunta por origen, destino, fechas de salida y regreso, motivo o venue y preferencias opcionales.\n"
+            "Nunca menciones políticas ni pidas datos personales antes de elegir opciones.\n"
+            "Muestra únicamente vuelos y hoteles dentro del presupuesto; incluye carry-on en todas las búsquedas de vuelos.\n"
+            "Cuando el usuario confirme vuelo y hotel, solicita: nombre completo y fecha de nacimiento (prellenados), número de pasaporte y visa si aplica.\n"
+            "Confirma que los datos sean correctos y envía la solicitud a Finanzas.\n"
+            "Permite correcciones en cualquier momento y evita repeticiones innecesarias."
         )
         context = "\n".join(
             f"Usuario: {h['user']}" if 'user' in h else f"Bot: {h['bot']}" for h in history[-5:]

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -12,6 +12,7 @@ def test_build_flight_params_full_dates():
     assert params["outbound_date"] == "2024-09-05"
     assert params["return_date"] == "2024-09-09"
     assert params["engine"] == "google_flights"
+    assert params["bags"] == "1"
 
 
 def test_build_flight_params_partial_dates():
@@ -21,6 +22,7 @@ def test_build_flight_params_partial_dates():
     assert params["arrival_id"] == "SFO"
     assert re.match(r"\d{4}-\d{2}-\d{2}", params["outbound_date"])
     assert re.match(r"\d{4}-\d{2}-\d{2}", params["return_date"])
+    assert params["bags"] == "1"
 
 
 def test_compound_city_and_one_way():
@@ -31,6 +33,7 @@ def test_compound_city_and_one_way():
     assert "return_date" not in params
     assert params.get("include_airlines") == "AM"
     assert params["travel_class"] == "2"
+    assert params["bags"] == "1"
 
 
 def test_default_dates_future_weekdays():
@@ -39,4 +42,5 @@ def test_default_dates_future_weekdays():
     out = date.fromisoformat(params["outbound_date"])
     assert out >= date.today() + timedelta(days=3)
     assert out.weekday() < 5
+    assert params["bags"] == "1"
 


### PR DESCRIPTION
## Summary
- include `bags` parameter in SerpApi wrapper and parameter builder
- adjust TravelAssistant prompt with conversation rules
- update tests for bags parameter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885e2d5b8e48325b5083c4b05c67b3f