### PR TITLE
Remove stub google package and update AI service

### DIFF
--- a/google/__init__.py
+++ b/google/__init__.py
@@ -1,2 +1,0 @@
-from pkgutil import extend_path
-__path__ = extend_path(__path__, __name__)

--- a/google/genai/__init__.py
+++ b/google/genai/__init__.py
@@ -1,9 +1,0 @@
-class Client:
-    def __init__(self, *args, **kwargs):
-        pass
-    class models:
-        @staticmethod
-        def generate_content(*args, **kwargs):
-            class Resp:
-                text = "ok"
-            return Resp()

--- a/services/ai.py
+++ b/services/ai.py
@@ -8,7 +8,7 @@ try:
     # The Client will read the GEMINI_API_KEY environment variable.
     client = genai.Client()
     GEMINI_AVAILABLE = True
-except Exception as e:
+except ImportError as e:
     logger.warning("Gemini not available: %s", e)
     client = None
     GEMINI_AVAILABLE = False

--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -1,5 +1,6 @@
 import sys, os
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+os.environ.setdefault("GEMINI_API_KEY", "dummy")
 import services.ai as ai_module
 from services.ai import ConversationalAI
 

--- a/tests/test_travel.py
+++ b/tests/test_travel.py
@@ -2,6 +2,7 @@ import sys, os, json
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.primitives import serialization
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+os.environ.setdefault("GEMINI_API_KEY", "dummy")
 
 if "service-account" not in os.environ:
     key = rsa.generate_private_key(public_exponent=65537, key_size=2048)


### PR DESCRIPTION
## Summary
- remove internal `google` stub to use the real library
- handle ImportError only when loading `google.genai`
- adapt unit tests to supply a dummy API key

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q cryptography`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885f8b8a28c8325a8ec75ca03cee19a