### PR TITLE
Align SERVICE_ACCOUNT env name

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Configura un archivo `.env` (o exporta en tu entorno) con:
 GEMINI_API_KEY=<tu_api_key>
 SLACK_SIGNING_SECRET=<tu_signing_secret>
 SLACK_BOT_TOKEN=<tu_bot_token>
-service-account='<contenido_json>'
+SERVICE_ACCOUNT='<contenido_json>'
 GOOGLE_SHEET_ID=<id_de_tu_hoja>
 SERPAPI_KEY=<tu_clave_serpapi>
 ```

--- a/services/firebase.py
+++ b/services/firebase.py
@@ -8,9 +8,9 @@ logger = logging.getLogger(__name__)
 
 class FirebaseService:
     def __init__(self):
-        creds_json = os.environ.get("service-account")
+        creds_json = os.environ.get("SERVICE_ACCOUNT")
         if not creds_json:
-            raise RuntimeError("service-account environment variable not set")
+            raise RuntimeError("SERVICE_ACCOUNT environment variable not set")
         creds_info = json.loads(creds_json)
         self.client = firestore.Client.from_service_account_info(creds_info)
 

--- a/services/sheets.py
+++ b/services/sheets.py
@@ -10,9 +10,9 @@ SCOPES = ["https://www.googleapis.com/auth/spreadsheets.readonly"]
 
 class SheetService:
     def __init__(self):
-        creds_json = os.environ.get("service-account")
+        creds_json = os.environ.get("SERVICE_ACCOUNT")
         if not creds_json:
-            raise RuntimeError("service-account environment variable not set")
+            raise RuntimeError("SERVICE_ACCOUNT environment variable not set")
         creds_info = json.loads(creds_json)
         creds = Credentials.from_service_account_info(creds_info, scopes=SCOPES)
         self.client = gspread.authorize(creds)

--- a/tests/test_travel.py
+++ b/tests/test_travel.py
@@ -3,14 +3,14 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.primitives import serialization
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
-if "service-account" not in os.environ:
+if "SERVICE_ACCOUNT" not in os.environ:
     key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
     private_key = key.private_bytes(
         encoding=serialization.Encoding.PEM,
         format=serialization.PrivateFormat.PKCS8,
         encryption_algorithm=serialization.NoEncryption(),
     ).decode()
-    os.environ["service-account"] = json.dumps(
+    os.environ["SERVICE_ACCOUNT"] = json.dumps(
         {
             "type": "service_account",
             "project_id": "dummy",


### PR DESCRIPTION
## Summary
- use `SERVICE_ACCOUNT` env var in Firebase and Sheets services
- update tests and docs to use the unified name

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886931cff0c8325bb69f94585dad33b