### PR TITLE
Fix Gemini client initialization

### DIFF
--- a/services/ai.py
+++ b/services/ai.py
@@ -1,13 +1,14 @@
 import logging
+import os
 
 logger = logging.getLogger(__name__)
 
 try:
     from google import genai
 
-    # The Client will read the GEMINI_API_KEY environment variable.
-    client = genai.Client()
-    GEMINI_AVAILABLE = True
+    api_key = os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY")
+    client = genai.Client(api_key=api_key) if api_key else None
+    GEMINI_AVAILABLE = client is not None
 except ImportError as e:
     logger.warning("Gemini not available: %s", e)
     client = None


### PR DESCRIPTION
## Summary
- initialize Gemini client using environment API key if available

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887971184248325b8f6a2e9f9c48d72